### PR TITLE
Create interactive scoreboard main page

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,1 +1,95 @@
 /* Your app custom styles here */
+
+.scoreboard-page {
+  .navbar .right .link {
+    color: inherit;
+  }
+
+  .page-content {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+}
+
+.scoreboard-layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  min-height: 0;
+}
+
+.scoreboard-side {
+  border: none;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 1rem;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.scoreboard-side:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.8);
+  outline-offset: -3px;
+}
+
+.scoreboard-side--left {
+  background: linear-gradient(135deg, #ff7875, #ff4d4f);
+}
+
+.scoreboard-side--right {
+  background: linear-gradient(135deg, #69c0ff, #1677ff);
+}
+
+.scoreboard-display {
+  align-self: center;
+  justify-self: center;
+  background: #111111;
+  color: #ffffff;
+  border-radius: 24px;
+  padding: 2rem 3rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.scoreboard-display__score {
+  font-size: clamp(3rem, 8vw, 6rem);
+  line-height: 1;
+  font-weight: 700;
+  min-width: 3ch;
+}
+
+.scoreboard-display__separator {
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  font-weight: 300;
+}
+
+.scoreboard-side__label {
+  opacity: 0.85;
+}
+
+@media (max-width: 768px) {
+  .scoreboard-display {
+    padding: 1.5rem 2rem;
+    gap: 1rem;
+  }
+
+  .scoreboard-side {
+    font-size: 1.2rem;
+  }
+}

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,74 +1,60 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Page,
   Navbar,
-  NavLeft,
   NavTitle,
-  NavTitleLarge,
   NavRight,
   Link,
-  Toolbar,
-  Block,
-  BlockTitle,
-  List,
-  ListItem,
-  Button
 } from 'framework7-react';
 
-const HomePage = () => (
-  <Page name="home">
-    {/* Top Navbar */}
-    <Navbar large sliding={false}>
-      <NavLeft>
-        <Link iconIos="f7:menu" iconMd="material:menu" panelOpen="left" />
-      </NavLeft>
-      <NavTitle sliding>Scoreboard</NavTitle>
-      <NavRight>
-        <Link iconIos="f7:menu" iconMd="material:menu" panelOpen="right" />
-      </NavRight>
-      <NavTitleLarge>Scoreboard</NavTitleLarge>
-    </Navbar>
-    {/* Toolbar */}
-    <Toolbar bottom>
-      <Link>Left Link</Link>
-      <Link>Right Link</Link>
-    </Toolbar>
-    {/* Page content */}
-    <Block>
-      <p>Here is your blank Framework7 app. Let's see what we have here.</p>
-    </Block>
-    <BlockTitle>Navigation</BlockTitle>
-    <List strong inset dividersIos>
-      <ListItem link="/about/" title="About"/>
-      <ListItem link="/form/" title="Form"/>
-    </List>
+const HomePage = () => {
+  const [leftScore, setLeftScore] = useState(0);
+  const [rightScore, setRightScore] = useState(0);
 
-    <BlockTitle>Modals</BlockTitle>
-    <Block className="grid grid-cols-2 grid-gap">
-      <Button fill popupOpen="#my-popup">Popup</Button>
-      <Button fill loginScreenOpen="#my-login-screen">Login Screen</Button>
-    </Block>
+  const incrementLeft = useCallback(() => {
+    setLeftScore((score) => score + 1);
+  }, []);
 
-    <BlockTitle>Panels</BlockTitle>
-    <Block className="grid grid-cols-2 grid-gap">
-      <Button fill panelOpen="left">Left Panel</Button>
-      <Button fill panelOpen="right">Right Panel</Button>
-    </Block>
+  const incrementRight = useCallback(() => {
+    setRightScore((score) => score + 1);
+  }, []);
 
-    <List strong inset dividersIos>
-      <ListItem
-        title="Dynamic (Component) Route"
-        link="/dynamic-route/blog/45/post/125/?foo=bar#about"
-      />
-      <ListItem
-        title="Default Route (404)"
-        link="/load-something-that-doesnt-exist/"
-      />
-      <ListItem
-        title="Request Data & Load"
-        link="/request-and-load/user/123456/"
-      />
-    </List>
-  </Page>
-);
+  const resetScores = useCallback(() => {
+    setLeftScore(0);
+    setRightScore(0);
+  }, []);
+
+  return (
+    <Page name="home" className="scoreboard-page">
+      <Navbar>
+        <NavTitle>Scoreboard</NavTitle>
+        <NavRight>
+          <Link iconF7="arrow_counterclockwise" aria-label="Reset scores" onClick={resetScores} />
+        </NavRight>
+      </Navbar>
+      <div className="scoreboard-layout">
+        <button
+          type="button"
+          className="scoreboard-side scoreboard-side--left"
+          onClick={incrementLeft}
+        >
+          <span className="scoreboard-side__label">LEFT</span>
+        </button>
+        <div className="scoreboard-display">
+          <span className="scoreboard-display__score">{leftScore}</span>
+          <span className="scoreboard-display__separator">:</span>
+          <span className="scoreboard-display__score">{rightScore}</span>
+        </div>
+        <button
+          type="button"
+          className="scoreboard-side scoreboard-side--right"
+          onClick={incrementRight}
+        >
+          <span className="scoreboard-side__label">RIGHT</span>
+        </button>
+      </div>
+    </Page>
+  );
+};
+
 export default HomePage;


### PR DESCRIPTION
## Summary
- replace the default home page layout with an interactive scoreboard that tracks left and right scores and includes a reset control
- add responsive styling for the red and blue touch zones and central score display

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8fcd16ee8832483c07f3ee15e59db