### PR TITLE
Update scoreboard layout to split-screen buttons

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -16,28 +16,29 @@
 
 .scoreboard-layout {
   flex: 1;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  display: flex;
   align-items: stretch;
   min-height: 0;
 }
 
 .scoreboard-side {
+  flex: 1;
   border: none;
-  background: transparent;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.75rem;
   color: #ffffff;
-  font-size: 1.5rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
   padding: 1rem;
-  width: 100%;
-  height: 100%;
+  min-width: 0;
   cursor: pointer;
+  text-transform: uppercase;
+  transition: transform 0.2s ease;
+}
+
+.scoreboard-side:active {
+  transform: scale(0.97);
 }
 
 .scoreboard-side:focus-visible {
@@ -53,43 +54,30 @@
   background: linear-gradient(135deg, #69c0ff, #1677ff);
 }
 
-.scoreboard-display {
-  align-self: center;
-  justify-self: center;
-  background: #111111;
-  color: #ffffff;
-  border-radius: 24px;
-  padding: 2rem 3rem;
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
-  text-align: center;
-}
-
-.scoreboard-display__score {
-  font-size: clamp(3rem, 8vw, 6rem);
+.scoreboard-side__score {
+  font-size: clamp(4rem, 12vw, 8rem);
   line-height: 1;
   font-weight: 700;
-  min-width: 3ch;
-}
-
-.scoreboard-display__separator {
-  font-size: clamp(2.5rem, 6vw, 4rem);
-  font-weight: 300;
+  letter-spacing: 0.06em;
 }
 
 .scoreboard-side__label {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
   opacity: 0.85;
 }
 
 @media (max-width: 768px) {
-  .scoreboard-display {
-    padding: 1.5rem 2rem;
-    gap: 1rem;
+  .scoreboard-side {
+    padding: 2rem 1rem;
   }
 
-  .scoreboard-side {
-    font-size: 1.2rem;
+  .scoreboard-side__score {
+    font-size: clamp(3rem, 22vw, 6rem);
+  }
+
+  .scoreboard-side__label {
+    font-size: 1rem;
   }
 }

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -38,18 +38,15 @@ const HomePage = () => {
           className="scoreboard-side scoreboard-side--left"
           onClick={incrementLeft}
         >
+          <span className="scoreboard-side__score">{leftScore}</span>
           <span className="scoreboard-side__label">LEFT</span>
         </button>
-        <div className="scoreboard-display">
-          <span className="scoreboard-display__score">{leftScore}</span>
-          <span className="scoreboard-display__separator">:</span>
-          <span className="scoreboard-display__score">{rightScore}</span>
-        </div>
         <button
           type="button"
           className="scoreboard-side scoreboard-side--right"
           onClick={incrementRight}
         >
+          <span className="scoreboard-side__score">{rightScore}</span>
           <span className="scoreboard-side__label">RIGHT</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- restructure the home scoreboard view so each side of the screen is a tappable half-width button that shows its score
- refresh the scoreboard styling to remove the black center panel and present large white scores centered on each side

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ffd70a2483248bfaa6b1800d2c7d